### PR TITLE
Platform-specific implementations for secret memory allocation

### DIFF
--- a/src/alloc/linux.rs
+++ b/src/alloc/linux.rs
@@ -1,7 +1,13 @@
-use core::{alloc::Layout, ptr::NonNull};
+use core::{
+    alloc::Layout,
+    ptr::{self, NonNull},
+};
 use std::io;
 
-use super::SecretAllocator;
+use libc::{SYS_memfd_secret, MAP_FAILED, MAP_SHARED, PROT_READ, PROT_WRITE};
+use zeroize::Zeroize;
+
+use super::{util, SecretAllocator};
 
 // FIXME Current implementation wastes memory
 /// Provides an implementation of the `SecretAllocator` trait for Linux systems.
@@ -19,20 +25,71 @@ impl LinuxSecretAllocator {
 
 impl SecretAllocator for LinuxSecretAllocator {
     fn alloc(&self, layout: Layout) -> io::Result<NonNull<u8>> {
-        todo!()
+        let size = util::aligned_layout_size(&layout);
+
+        let mmap = match unsafe { libc::syscall(SYS_memfd_secret, 0) } as libc::c_int {
+            -1 => return Err(io::Error::last_os_error()),
+            fd => {
+                if unsafe { libc::ftruncate(fd, size as libc::off_t) } < 0 {
+                    unsafe { libc::close(fd) };
+                    return Err(io::Error::last_os_error());
+                }
+
+                let mmap = unsafe {
+                    libc::mmap(
+                        ptr::null_mut(),
+                        size,
+                        PROT_WRITE | PROT_READ,
+                        MAP_SHARED,
+                        fd,
+                        0,
+                    )
+                };
+
+                unsafe { libc::close(fd) };
+                mmap
+            }
+        };
+
+        match mmap {
+            MAP_FAILED => Err(io::Error::last_os_error()),
+            ptr => {
+                let ptr = unsafe { NonNull::new_unchecked(ptr as *mut _) };
+                Ok(ptr)
+            }
+        }
     }
 
     // NOTE Protection acts on an entire page, not a section.
     fn make_read_only(&self, ptr: NonNull<u8>, layout: Layout) -> io::Result<()> {
-        todo!()
+        let size = util::aligned_layout_size(&layout);
+        match unsafe { libc::mprotect(ptr.as_ptr() as *mut _, size, PROT_READ) } {
+            -1 => Err(io::Error::last_os_error()),
+            _ => Ok(()),
+        }
     }
 
     // NOTE Protection acts on an entire page, not a section.
     fn make_writable(&self, ptr: NonNull<u8>, layout: Layout) -> io::Result<()> {
-        todo!()
+        let size = util::aligned_layout_size(&layout);
+        match unsafe { libc::mprotect(ptr.as_ptr() as *mut _, size, PROT_WRITE | PROT_READ) } {
+            -1 => Err(io::Error::last_os_error()),
+            _ => Ok(()),
+        }
     }
 
     fn dealloc(&self, ptr: NonNull<u8>, layout: Layout) -> io::Result<()> {
-        todo!()
+        self.make_writable(ptr, layout)?;
+        let size = util::aligned_layout_size(&layout);
+
+        Zeroize::zeroize({
+            let bytes_slice = ptr::slice_from_raw_parts_mut(ptr.as_ptr(), size);
+            unsafe { &mut *bytes_slice }
+        });
+
+        match unsafe { libc::munmap(ptr.as_ptr() as *mut _, size) } {
+            -1 => Err(io::Error::last_os_error()),
+            _ => Ok(()),
+        }
     }
 }

--- a/src/alloc/linux.rs
+++ b/src/alloc/linux.rs
@@ -88,3 +88,49 @@ impl SecretAllocator for LinuxSecretAllocator {
         }
     }
 }
+
+// NOTE The test cannot be started via `cargo test` due to the nature of the `SYS_MEMFD_SECRET'
+//      call, which results in a `SIGBUS' error.
+//
+// #[cfg(test)]
+// mod tests {
+//     use core::{alloc::Layout, ptr, str};
+//     use std::io::Write as _;
+//
+//     use super::*;
+//
+//     #[test]
+//     fn test_linux_implementation() {
+//         let allocator = LinuxSecretAllocator::new();
+//         let layout = unsafe { Layout::from_size_align_unchecked(1024, 8) }; // Allocate 1KB with 8-byte alignment
+//
+//         // Assert that allocation was successful
+//         let result = allocator.alloc(layout);
+//         assert!(result.is_ok());
+//
+//         let ptr = unsafe { result.unwrap_unchecked() };
+//
+//         // Attempt to write into the allocation
+//         let result = {
+//             let mut slice_mut =
+//                 unsafe { &mut *ptr::slice_from_raw_parts_mut(ptr.as_ptr(), layout.size()) };
+//             write!(slice_mut, "Hello, World!")
+//         };
+//         assert!(result.is_ok());
+//
+//         // Assert that make_readonly was successful
+//         let result = allocator.make_read_only(ptr, layout);
+//         assert!(result.is_ok());
+//
+//         // Attempt to read from the allocation
+//         let result = {
+//             let slice_mut = unsafe { &*ptr::slice_from_raw_parts(ptr.as_ptr(), layout.size()) };
+//             str::from_utf8(slice_mut)
+//         };
+//         assert!(result.is_ok_and(|s| &s[..13] == "Hello, World!"));
+//
+//         // Assert that deallocation was successful
+//         let result = allocator.dealloc(ptr, layout);
+//         assert!(result.is_ok());
+//     }
+// }

--- a/src/alloc/linux.rs
+++ b/src/alloc/linux.rs
@@ -4,20 +4,20 @@ use std::io;
 use super::SecretAllocator;
 
 // FIXME Current implementation wastes memory
-/// Provides an implementation of the `SecretAllocator` trait for Unix-based systems.
+/// Provides an implementation of the `SecretAllocator` trait for Linux systems.
 ///
-/// This implementation relies on Unix system calls to manage memory in a way that
-/// limits its visibility to other processes and prevents sensitive data from being
-/// leaked.
-pub struct UnixSecretAllocator(());
+/// This implementation relies on Linux `SYS_memfd_secret` and Unix system calls
+/// to manage memory in a way that limits its visibility to other processes and
+/// prevents sensitive data from being leaked.
+pub struct LinuxSecretAllocator(());
 
-impl UnixSecretAllocator {
+impl LinuxSecretAllocator {
     pub fn new() -> Self {
         Self(())
     }
 }
 
-impl SecretAllocator for UnixSecretAllocator {
+impl SecretAllocator for LinuxSecretAllocator {
     fn alloc(&self, layout: Layout) -> io::Result<NonNull<u8>> {
         todo!()
     }

--- a/src/alloc/mod.rs
+++ b/src/alloc/mod.rs
@@ -70,7 +70,21 @@ pub trait SecretAllocator {
 }
 
 mod util {
-    use std::sync::OnceLock;
+    use std::{alloc::Layout, cmp, sync::OnceLock};
+
+    /// Returns the size of a memory layout aligned to the system's page size.
+    ///
+    /// # Arguments
+    /// * `layout` - A memory layout specifying size and alignment.
+    ///
+    /// # Panics
+    /// This function panics if alignment fails (which should not happen,
+    /// as alignment to the page size is expected to succeed).
+    pub fn aligned_layout_size(layout: &Layout) -> usize {
+        let size = layout.size();
+        let align = cmp::max(layout.align(), self::page_size());
+        size.wrapping_add(align).wrapping_sub(1) & !align.wrapping_sub(1)
+    }
 
     /// Returns the system's memory page size in bytes.
     ///

--- a/src/alloc/mod.rs
+++ b/src/alloc/mod.rs
@@ -109,7 +109,8 @@ pub fn platform_secret_allocator() -> &'static dyn SecretAllocator {
 }
 
 mod util {
-    use std::{alloc::Layout, cmp, sync::OnceLock};
+    use core::{alloc::Layout, cmp};
+    use std::sync::OnceLock;
 
     /// Returns the size of a memory layout aligned to the system's page size.
     ///

--- a/src/alloc/mod.rs
+++ b/src/alloc/mod.rs
@@ -170,4 +170,35 @@ mod util {
             }
         })
     }
+
+    #[cfg(test)]
+    mod tests {
+        use core::alloc::Layout;
+
+        use super::*;
+
+        #[test]
+        fn test_aligned_layout_size_with_page_size() {
+            let page_size = page_size();
+
+            // Layout with size less than page size, aligned to page size
+            let layout = Layout::from_size_align(1000, 8).unwrap();
+            let aligned_size = aligned_layout_size(&layout);
+            assert_eq!(aligned_size, page_size);
+
+            // Layout with size larger than a page size
+            let layout = Layout::from_size_align(page_size + 1, 8).unwrap();
+            let aligned_size = aligned_layout_size(&layout);
+            assert_eq!(aligned_size, page_size * 2);
+        }
+
+        #[test]
+        fn test_page_size() {
+            let page_size = page_size();
+
+            // Assert that the page size is greater than 0 and a common power of two (e.g., 4096, 8192)
+            assert!(page_size > 0);
+            assert!(page_size.is_power_of_two());
+        }
+    }
 }

--- a/src/alloc/mod.rs
+++ b/src/alloc/mod.rs
@@ -25,7 +25,7 @@ pub trait SecretAllocator {
     /// - On success, returns a `NonNull<u8>` pointer to the beginning of the allocated
     ///   memory block.
     /// - On failure, returns an `io::Result` containing the error.
-    fn alloc(layout: Layout) -> io::Result<NonNull<u8>>;
+    fn alloc(&self, layout: Layout) -> io::Result<NonNull<u8>>;
 
     /// Changes the access permissions of a memory region to make it read-only.
     ///
@@ -38,7 +38,7 @@ pub trait SecretAllocator {
     ///
     /// # Returns:
     /// On success, returns `Ok(())`. On failure, returns an `io::Error`.
-    fn make_read_only(ptr: NonNull<u8>, layout: Layout) -> io::Result<()>;
+    fn make_read_only(&self, ptr: NonNull<u8>, layout: Layout) -> io::Result<()>;
 
     /// Changes the access permissions of a memory region to make it writable.
     ///
@@ -52,7 +52,7 @@ pub trait SecretAllocator {
     ///
     /// # Returns:
     /// On success, returns `Ok(())`. On failure, returns an `io::Error`.
-    fn make_writable(ptr: NonNull<u8>, layout: Layout) -> io::Result<()>;
+    fn make_writable(&self, ptr: NonNull<u8>, layout: Layout) -> io::Result<()>;
 
     /// Deallocates a previously allocated memory region.
     ///
@@ -66,7 +66,7 @@ pub trait SecretAllocator {
     ///
     /// # Returns:
     /// On success, returns `Ok(())`. On failure, returns an `io::Error`.
-    fn dealloc(ptr: NonNull<u8>, layout: Layout) -> io::Result<()>;
+    fn dealloc(&self, ptr: NonNull<u8>, layout: Layout) -> io::Result<()>;
 }
 
 mod util {

--- a/src/alloc/unix.rs
+++ b/src/alloc/unix.rs
@@ -3,27 +3,36 @@ use std::io;
 
 use super::SecretAllocator;
 
+// FIXME Current implementation wastes memory
 /// Provides an implementation of the `SecretAllocator` trait for Unix-based systems.
 ///
 /// This implementation relies on Unix system calls to manage memory in a way that
 /// limits its visibility to other processes and prevents sensitive data from being
 /// leaked.
-pub struct UnixSecretAllocator;
+pub struct UnixSecretAllocator(());
+
+impl UnixSecretAllocator {
+    pub fn instance() -> Self {
+        Self(())
+    }
+}
 
 impl SecretAllocator for UnixSecretAllocator {
-    fn alloc(layout: Layout) -> io::Result<NonNull<u8>> {
+    fn alloc(&self, layout: Layout) -> io::Result<NonNull<u8>> {
         todo!()
     }
 
-    fn make_read_only(ptr: NonNull<u8>, layout: Layout) -> io::Result<()> {
+    // NOTE Protection acts on an entire page, not a section.
+    fn make_read_only(&self, ptr: NonNull<u8>, layout: Layout) -> io::Result<()> {
         todo!()
     }
 
-    fn make_writable(ptr: NonNull<u8>, layout: Layout) -> io::Result<()> {
+    // NOTE Protection acts on an entire page, not a section.
+    fn make_writable(&self, ptr: NonNull<u8>, layout: Layout) -> io::Result<()> {
         todo!()
     }
 
-    fn dealloc(ptr: NonNull<u8>, layout: Layout) -> io::Result<()> {
+    fn dealloc(&self, ptr: NonNull<u8>, layout: Layout) -> io::Result<()> {
         todo!()
     }
 }

--- a/src/alloc/unix.rs
+++ b/src/alloc/unix.rs
@@ -47,16 +47,10 @@ impl SecretAllocator for UnixSecretAllocator {
             return Err(io::Error::last_os_error());
         }
 
-        let madvise_result = unsafe {
-            #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
-            {
-                libc::madvise(mmap, size, libc::MADV_NOCORE)
-            }
-            #[cfg(not(any(target_os = "freebsd", target_os = "dragonfly")))]
-            {
-                libc::madvise(mmap, size, libc::MADV_DONTDUMP)
-            }
-        };
+        #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+        let madvise_result = unsafe { libc::madvise(mmap, size, libc::MADV_NOCORE) };
+        #[cfg(not(any(target_os = "freebsd", target_os = "dragonfly")))]
+        let madvise_result = unsafe { libc::madvise(mmap, size, libc::MADV_DONTDUMP) };
 
         if madvise_result < 0 {
             unsafe {

--- a/src/alloc/unix.rs
+++ b/src/alloc/unix.rs
@@ -111,3 +111,48 @@ impl SecretAllocator for UnixSecretAllocator {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use core::{alloc::Layout, ptr, str};
+    use std::io::Write as _;
+
+    use super::*;
+
+    #[test]
+    fn test_unix_implementation() {
+        let allocator = UnixSecretAllocator::new();
+        let layout = unsafe { Layout::from_size_align_unchecked(1024, 8) }; // Allocate 1KB with 8-byte alignment
+
+        let ptr = {
+            // Assert that allocation was successful
+            let result = allocator.alloc(layout);
+            assert!(result.is_ok());
+
+            unsafe { result.unwrap_unchecked() }
+        };
+
+        // Attempt to write into the allocation
+        let result = {
+            let mut slice_mut =
+                unsafe { &mut *ptr::slice_from_raw_parts_mut(ptr.as_ptr(), layout.size()) };
+            write!(slice_mut, "Hello, World!")
+        };
+        assert!(result.is_ok());
+
+        // Assert that make_readonly was successful
+        let result = allocator.make_read_only(ptr, layout);
+        assert!(result.is_ok());
+
+        // Attempt to read from the allocation
+        let result = {
+            let slice_mut = unsafe { &*ptr::slice_from_raw_parts(ptr.as_ptr(), layout.size()) };
+            str::from_utf8(slice_mut)
+        };
+        assert!(result.is_ok_and(|s| &s[..13] == "Hello, World!"));
+
+        // Assert that deallocation was successful
+        let result = allocator.dealloc(ptr, layout);
+        assert!(result.is_ok());
+    }
+}

--- a/src/alloc/unix.rs
+++ b/src/alloc/unix.rs
@@ -1,7 +1,13 @@
-use core::{alloc::Layout, ptr::NonNull};
+use core::{
+    alloc::Layout,
+    ptr::{self, NonNull},
+};
 use std::io;
 
-use super::SecretAllocator;
+use libc::{MAP_ANON, MAP_FAILED, MAP_PRIVATE, PROT_READ, PROT_WRITE};
+use zeroize::Zeroize;
+
+use super::{util, SecretAllocator};
 
 // FIXME Current implementation wastes memory
 /// Provides an implementation of the `SecretAllocator` trait for Unix-based systems.
@@ -19,20 +25,93 @@ impl UnixSecretAllocator {
 
 impl SecretAllocator for UnixSecretAllocator {
     fn alloc(&self, layout: Layout) -> io::Result<NonNull<u8>> {
-        todo!()
+        let size = util::aligned_layout_size(&layout);
+
+        let mmap = unsafe {
+            libc::mmap(
+                ptr::null_mut(),
+                size,
+                PROT_WRITE | PROT_READ,
+                MAP_PRIVATE | MAP_ANON,
+                -1,
+                0,
+            )
+        };
+
+        if mmap == MAP_FAILED {
+            return Err(io::Error::last_os_error());
+        }
+
+        if unsafe { libc::mlock(mmap, size) } < 0 {
+            unsafe { libc::munmap(mmap, size) };
+            return Err(io::Error::last_os_error());
+        }
+
+        let madvise_result = unsafe {
+            #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+            {
+                libc::madvise(mmap, size, libc::MADV_NOCORE)
+            }
+            #[cfg(not(any(target_os = "freebsd", target_os = "dragonfly")))]
+            {
+                libc::madvise(mmap, size, libc::MADV_DONTDUMP)
+            }
+        };
+
+        if madvise_result < 0 {
+            unsafe {
+                libc::munlock(mmap, size);
+                libc::munmap(mmap, size);
+            }
+
+            return Err(io::Error::last_os_error());
+        }
+
+        let mmap = unsafe { NonNull::new_unchecked(mmap as *mut _) };
+        Ok(mmap)
     }
 
     // NOTE Protection acts on an entire page, not a section.
     fn make_read_only(&self, ptr: NonNull<u8>, layout: Layout) -> io::Result<()> {
-        todo!()
+        let size = util::aligned_layout_size(&layout);
+
+        if unsafe { libc::mprotect(ptr.as_ptr() as *mut _, size, PROT_READ) } < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        Ok(())
     }
 
     // NOTE Protection acts on an entire page, not a section.
     fn make_writable(&self, ptr: NonNull<u8>, layout: Layout) -> io::Result<()> {
-        todo!()
+        let size = util::aligned_layout_size(&layout);
+
+        if unsafe { libc::mprotect(ptr.as_ptr() as *mut _, size, PROT_WRITE | PROT_READ) } < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        Ok(())
     }
 
     fn dealloc(&self, ptr: NonNull<u8>, layout: Layout) -> io::Result<()> {
-        todo!()
+        self.make_writable(ptr, layout)?;
+        let size = util::aligned_layout_size(&layout);
+
+        Zeroize::zeroize({
+            let bytes_slice = ptr::slice_from_raw_parts_mut(ptr.as_ptr(), size);
+            unsafe { &mut *bytes_slice }
+        });
+
+        unsafe {
+            #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+            libc::madvise(ptr.as_ptr() as *mut _, self.len, libc::MADV_CORE);
+            #[cfg(not(any(target_os = "freebsd", target_os = "dragonfly")))]
+            libc::madvise(ptr.as_ptr() as *mut _, size, libc::MADV_DODUMP);
+
+            libc::munlock(ptr.as_ptr() as *mut _, size);
+            libc::munmap(ptr.as_ptr() as *mut _, size);
+        }
+
+        Ok(())
     }
 }

--- a/src/alloc/windows.rs
+++ b/src/alloc/windows.rs
@@ -12,7 +12,7 @@ use super::SecretAllocator;
 pub struct WindowsSecretAllocator(());
 
 impl WindowsSecretAllocator {
-    pub fn instance() -> Self {
+    pub fn new() -> Self {
         Self(())
     }
 }

--- a/src/alloc/windows.rs
+++ b/src/alloc/windows.rs
@@ -3,27 +3,36 @@ use std::io;
 
 use super::SecretAllocator;
 
+// FIXME Current implementation wastes memory
 /// Provides an implementation of the `SecretAllocator` trait for Windows systems.
 ///
 /// This implementation relies on Windows system calls to manage memory in a way that
 /// limits its visibility to other processes and prevents sensitive data from being
 /// leaked.
-pub struct WindowsSecretAllocator;
+pub struct WindowsSecretAllocator(());
+
+impl WindowsSecretAllocator {
+    pub fn instance() -> Self {
+        Self(())
+    }
+}
 
 impl SecretAllocator for WindowsSecretAllocator {
-    fn alloc(layout: Layout) -> io::Result<NonNull<u8>> {
+    fn alloc(&self, layout: Layout) -> io::Result<NonNull<u8>> {
         todo!()
     }
 
-    fn make_read_only(ptr: NonNull<u8>, layout: Layout) -> io::Result<()> {
+    // NOTE Protection acts on an entire page, not a section.
+    fn make_read_only(&self, ptr: NonNull<u8>, layout: Layout) -> io::Result<()> {
         todo!()
     }
 
-    fn make_writable(ptr: NonNull<u8>, layout: Layout) -> io::Result<()> {
+    // NOTE Protection acts on an entire page, not a section.
+    fn make_writable(&self, ptr: NonNull<u8>, layout: Layout) -> io::Result<()> {
         todo!()
     }
 
-    fn dealloc(ptr: NonNull<u8>, layout: Layout) -> io::Result<()> {
+    fn dealloc(&self, ptr: NonNull<u8>, layout: Layout) -> io::Result<()> {
         todo!()
     }
 }

--- a/src/alloc/windows.rs
+++ b/src/alloc/windows.rs
@@ -1,7 +1,16 @@
-use core::{alloc::Layout, ptr::NonNull};
+use core::{
+    alloc::Layout,
+    ptr::{self, NonNull},
+};
 use std::io;
 
-use super::SecretAllocator;
+use windows_sys::Win32::System::Memory::{
+    self as windows, MEM_COMMIT, MEM_RELEASE, MEM_RESERVE, PAGE_NOCACHE, PAGE_READONLY,
+    PAGE_READWRITE,
+};
+use zeroize::Zeroize;
+
+use super::{util, SecretAllocator};
 
 // FIXME Current implementation wastes memory
 /// Provides an implementation of the `SecretAllocator` trait for Windows systems.
@@ -19,20 +28,80 @@ impl WindowsSecretAllocator {
 
 impl SecretAllocator for WindowsSecretAllocator {
     fn alloc(&self, layout: Layout) -> io::Result<NonNull<u8>> {
-        todo!()
+        let size = util::aligned_layout_size(&layout);
+
+        let virt_alloc = unsafe {
+            windows::VirtualAlloc(
+                ptr::null_mut(),
+                size,
+                MEM_COMMIT | MEM_RESERVE,
+                PAGE_READWRITE | PAGE_NOCACHE,
+            )
+        };
+
+        if virt_alloc.is_null() {
+            return Err(io::Error::last_os_error());
+        }
+
+        if unsafe { windows::VirtualLock(virt_alloc, size) } == 0 {
+            let last_error = io::Error::last_os_error();
+            unsafe { windows::VirtualFree(virt_alloc, 0, MEM_RELEASE) };
+            return Err(last_error);
+        }
+
+        let ptr = unsafe { NonNull::new_unchecked(virt_alloc as *mut _) };
+        Ok(ptr)
     }
 
     // NOTE Protection acts on an entire page, not a section.
     fn make_read_only(&self, ptr: NonNull<u8>, layout: Layout) -> io::Result<()> {
-        todo!()
+        let size = util::aligned_layout_size(&layout);
+        let prot_result = unsafe {
+            windows::VirtualProtect(
+                ptr.as_ptr() as *mut _,
+                size,
+                PAGE_READONLY,
+                (&mut 0u32) as *mut _,
+            )
+        };
+
+        match prot_result {
+            0 => Err(io::Error::last_os_error()),
+            _ => Ok(()),
+        }
     }
 
     // NOTE Protection acts on an entire page, not a section.
     fn make_writable(&self, ptr: NonNull<u8>, layout: Layout) -> io::Result<()> {
-        todo!()
+        let size = util::aligned_layout_size(&layout);
+        let prot_result = unsafe {
+            windows::VirtualProtect(
+                ptr.as_ptr() as *mut _,
+                size,
+                PAGE_READWRITE,
+                (&mut 0u32) as *mut _,
+            )
+        };
+
+        match prot_result {
+            0 => Err(io::Error::last_os_error()),
+            _ => Ok(()),
+        }
     }
 
     fn dealloc(&self, ptr: NonNull<u8>, layout: Layout) -> io::Result<()> {
-        todo!()
+        self.make_writable(ptr, layout)?;
+        let size = util::aligned_layout_size(&layout);
+
+        Zeroize::zeroize({
+            let bytes_slice = ptr::slice_from_raw_parts_mut(ptr.as_ptr(), size);
+            unsafe { &mut *bytes_slice }
+        });
+
+        unsafe { windows::VirtualUnlock(ptr.as_ptr() as *mut _, size) };
+        match unsafe { windows::VirtualFree(ptr.as_ptr() as *mut _, 0, MEM_RELEASE) } {
+            0 => Err(io::Error::last_os_error()),
+            _ => Ok(()),
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces support for secret memory allocation on Unix, Linux and Windows platforms, thereby providing a unified interface for the management of secret memory on different platforms.  

In order to guarantee the confidentiality of sensitive data, the implementation employs operating system (OS)-specific system calls, specifically `memfd_secret` (on Linux systems), `mmap` (on Unix-like OSes) and `VirtualAlloc` (on Windows systems).
